### PR TITLE
Use absolute file paths and fix file content formatting for context retrieval

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "displayName": "ChatGPT Copilot",
   "icon": "images/ai-logo.png",
   "description": "A forked version of the original ChatGPT Copilot Extension by jeanibarz (https://github.com/jeanibarz/chatgpt-copilot), providing additional features for VS Code integration.",
-  "version": "5.3.0",
+  "version": "5.4.0",
   "aiKey": "",
   "repository": {
     "url": "https://github.com/jeanibarz/chatgpt-copilot"


### PR DESCRIPTION
This PR updates the file context retrieval process by switching from relative file paths to absolute paths and includes a minor fix to how file contents are formatted when injected into the prompt.

#### Key Changes:
- **Absolute File Paths**: Replaced the use of relative paths with absolute file paths, removing the need for a configured project root path.
- **File Content Formatting**: Fixed a minor issue with how file content is formatted when being included in the prompt.

This change simplifies the configuration and improves prompt clarity by ensuring correct path and content formatting.